### PR TITLE
Allow multiple header fields with the same name

### DIFF
--- a/crates/itsi_server/src/ruby_types/itsi_http_response.rs
+++ b/crates/itsi_server/src/ruby_types/itsi_http_response.rs
@@ -347,7 +347,7 @@ impl ItsiHttpResponse {
         })?;
         let header_value = unsafe { HeaderValue::from_maybe_shared_unchecked(value) };
         if let Some(ref mut resp) = *self.data.response.write() {
-            resp.headers_mut().insert(header_name, header_value);
+            resp.headers_mut().append(header_name, header_value);
         }
         Ok(())
     }
@@ -364,7 +364,7 @@ impl ItsiHttpResponse {
                 })?;
                 for value in values {
                     let header_value = unsafe { HeaderValue::from_maybe_shared_unchecked(value) };
-                    headers_mut.insert(&header_name, header_value);
+                    headers_mut.append(&header_name, header_value);
                 }
             }
         }

--- a/gems/server/lib/itsi/server/rack_interface.rb
+++ b/gems/server/lib/itsi/server/rack_interface.rb
@@ -40,9 +40,12 @@ module Itsi
         # 2. Set Headers
         body_streamer = streaming_body?(body) ? body : headers.delete("rack.hijack")
         headers.each do |key, value|
-          unless value.is_a?(Array)
-            response[key] = value
-            next
+          value = if value.is_a?(::Array) && !value.empty?
+            value
+          elsif value.respond_to?(:to_s) && !value.to_s.empty?
+            value.to_s.split("\n")
+          else
+            nil
           end
 
           value.each do |v|

--- a/gems/server/test/rack/test_rack_server.rb
+++ b/gems/server/test/rack/test_rack_server.rb
@@ -212,6 +212,17 @@ class TestRackServer < Minitest::Test
     end
   end
 
+  def test_multi_field_headers
+    server(app_with_lint: lambda do |env|
+      [200, { "content-type" => "text/plain", "x-example" => ["one, two, three", "four, five"] }, ["Multiple Field Headers"]]
+    end) do
+      response = get_resp("/")
+      assert_equal "200", response.code
+      assert_equal "one, two, three, four, five", response["x-example"]
+      assert_equal "Multiple Field Headers", response.body
+    end
+  end
+
   def test_large_body
     large_text = "A" * 10_000
     server(app_with_lint: lambda do |env|


### PR DESCRIPTION
Some headers can be repeated, like `Set-Cookie`

Similar to what puma does: https://github.com/puma/puma/blob/1519350f9dafa511743d34bf673046bce08aadea/lib/puma/request.rb#L657-L663