### PR TITLE
Fix broken format in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## [0.2.18] - 2025-XX-XX
 ### WIP
--- Fixing error in auto-reload on Linux when reuse_port is false
--- Fix breaking of auto-reload on config file errors
--- include directive is relative (equivalent to require_relative)
--- Fixing preload gem group logic
--- Fix errors in interrupt handling during some debug flows
+- Fixing error in auto-reload on Linux when reuse_port is false
+- Fix breaking of auto-reload on config file errors
+- include directive is relative (equivalent to require_relative)
+- Fixing preload gem group logic
+- Fix errors in interrupt handling during some debug flows
 
 ## [0.2.17] - 2025-05-31
 - Enabled vectorized writes in IoSteam


### PR DESCRIPTION
I assume this should be a list, but it doesn't now. https://github.com/wouterken/itsi/blob/main/CHANGELOG.md
This PR fixes it.