### PR TITLE
Fix a broken link

### DIFF
--- a/examples/api_with_schema_and_controllers/README.md
+++ b/examples/api_with_schema_and_controllers/README.md
@@ -2,7 +2,7 @@
 Simple example of how you can use the following options:
 
 * https://itsi.fyi/middleware/endpoint/
-* https://itsi.fyi/middleware/endpoint/controller
+* https://itsi.fyi/middleware/controller
 * https://itsi.fyi/middleware/endpoint/schemas/
 
 to create validated JSON endpoints directly inside Itsi without a dedicated framework


### PR DESCRIPTION
It seems that `/middleware/controller` is a correct path.