### PR TITLE
Feat: Compile native gem(s)

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,48 @@
+# Builds and pushes precompiled gem versions to Rubygems when a new release tag is created.
+# Eg; creating/pushing a new tag `0.2.21` will generate and publish:
+# - itsi-server-0.2.21-x86_64-linux.gem
+# - itsi-scheduler-0.2.21-x86_64-linux.gem
+# - itsi-server-0.2.21-arm64-darwin.gem
+# - itsi-scheduler-0.2.21-arm64-darwin.gem
+
+name: Post-Release
+
+on:
+  push:
+    tags: ["*"]
+
+jobs:
+  compile-native:
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-22.04
+            platform: x86_64-linux
+            flags: "target-cpu=native"
+          - runner: macos-15
+            platform: arm64-darwin23
+            flags: "target-cpu=apple-m4"
+    runs-on: ${{ matrix.runner }}
+    env:
+      BUNDLE_WITHOUT: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true
+          cargo-cache: true
+
+      - name: Compile gem for ${{ matrix.platform }}
+        run: bundle exec rake precompile:${{ matrix.platform }}
+        env:
+          RUSTFLAGS: "-C ${{ matrix.flags }}"
+
+      - name: Push to RubyGems
+        run: |
+          mkdir -p ~/.gem
+          echo -e "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}" > ~/.gem/credentials
+          chmod 0600 ~/.gem/credentials
+          gem push pkg/*.gem
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}

--- a/Rakefile
+++ b/Rakefile
@@ -83,6 +83,22 @@ task :build_all do
   end
 end
 
+namespace :precompile do
+  %i[x86_64-linux arm64-darwin23].each do |platform|
+    task platform do
+      Rake::Task[:sync_crates].invoke
+      GEMS.each do |gem_info|
+        Dir.chdir(gem_info[:dir]) do
+          system("rake native:#{platform} gem") or raise 'Gem build failed'
+          built_gem = Dir["pkg/*.gem"].first
+          FileUtils.mkdir_p('../../pkg')
+          FileUtils.mv(built_gem, "../../#{built_gem.sub('-23.gem', '.gem')}")
+        end
+      end
+    end
+  end
+end
+
 task :test_env_up do
   system('terraform -chdir=tmp/sandbox/deploy apply')
 end


### PR DESCRIPTION
Adds a GH workflow to automatically compile and push native gem versions for **x86_64-linux** and **arm64-darwin** when a tag is pushed.

### Setup

- Merge the PR (I think workflows only become active after they're merged to main)
- Add `RUBYGEMS_API_KEY` to github secrets for the repo

### Usage

- Prep a release version, eg: `0.2.1`
- Build and publish the regular version of the gem in whatever way you do it now
- Create and push a new tag, eg: `git tag -a 0.2.1 && git push origin 0.2.1`
- The workflow should run jobs to create native versions of the gem(s) and push them to rubygems automatically

### Notes

- I initially tried using the docker-based setup provided by oxide-rb but ran into various issues [here for reference](https://github.com/wouterken/itsi/discussions/4#discussioncomment-14317559).
- There are some annoying formatting issues around building for Darwin at the moment; when invoking the task you have to specify the Darwin version in a suffix _without_ a hyphen, eg `rake native:arm64-darwin23`, the output of that task creates a file with a _hyphenated_ suffix (`*-arm64-darwin-23.gem`) but apparently the suffix is basically pointless and should be stripped out before publishing, eg `*-arm64-darwin.gem`. Related discussion here: https://github.com/rubygems/rubygems/issues/7407