### PR TITLE
Move TLS handshakes off accept loop

### DIFF
--- a/crates/itsi_server/src/server/binds/listener.rs
+++ b/crates/itsi_server/src/server/binds/listener.rs
@@ -14,12 +14,13 @@ use std::fmt::Display;
 use std::net::{IpAddr, SocketAddr, TcpListener};
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::sync::Arc;
+use std::time::Duration;
 use std::{os::unix::net::UnixListener, path::PathBuf};
 use tokio::net::TcpListener as TokioTcpListener;
 use tokio::net::UnixListener as TokioUnixListener;
 use tokio::net::{unix, TcpStream, UnixStream};
 use tokio::sync::watch::Receiver;
-use tokio_rustls::TlsAcceptor;
+use tokio::time::timeout;
 use tokio_stream::StreamExt;
 
 pub(crate) enum Listener {
@@ -93,7 +94,7 @@ impl TokioListener {
         }
     }
 
-    pub(crate) async fn accept(&self) -> Result<IoStream> {
+    pub(crate) async fn accept(&self) -> Result<AcceptedStream> {
         match self {
             TokioListener::Tcp(listener) => TokioListener::accept_tcp(listener).await,
             TokioListener::TcpTls(listener, acceptor) => {
@@ -106,9 +107,11 @@ impl TokioListener {
         }
     }
 
-    async fn accept_tcp(listener: &TokioTcpListener) -> Result<IoStream> {
+    async fn accept_tcp(listener: &TokioTcpListener) -> Result<AcceptedStream> {
         let tcp_stream = listener.accept().await?;
-        Self::to_tokio_io(Stream::TcpStream(tcp_stream), None).await
+        Ok(AcceptedStream::Ready(Self::to_plain_io(Stream::TcpStream(
+            tcp_stream,
+        ))))
     }
 
     pub async fn spawn_acme_event_task(&self, mut shutdown_receiver: Receiver<RunningPhase>) {
@@ -137,89 +140,131 @@ impl TokioListener {
     async fn accept_tls(
         listener: &TokioTcpListener,
         acceptor: &ItsiTlsAcceptor,
-    ) -> Result<IoStream> {
-        let tcp_stream = listener.accept().await?;
-        match acceptor {
-            ItsiTlsAcceptor::Manual(tls_acceptor) => {
-                Self::to_tokio_io(Stream::TcpStream(tcp_stream), Some(tls_acceptor)).await
-            }
-            ItsiTlsAcceptor::Automatic(acme_acceptor, _, rustls_config) => {
-                let accept_future = acme_acceptor.accept(tcp_stream.0);
-                match accept_future.await {
-                    Ok(None) => Err(ItsiError::Pass),
-                    Ok(Some(start_handshake)) => {
-                        let tls_stream = start_handshake.into_stream(rustls_config.clone()).await?;
-                        Ok(IoStream::TcpTls {
-                            stream: tls_stream,
-                            addr: SockAddr::Tcp(Arc::new(tcp_stream.1)),
-                        })
-                    }
-                    Err(error) => {
-                        error!(error = format!("{:?}", error));
-                        Err(ItsiError::Pass)
-                    }
-                }
-            }
-        }
+    ) -> Result<AcceptedStream> {
+        let (stream, addr) = listener.accept().await?;
+        Ok(AcceptedStream::TcpTls {
+            stream,
+            addr,
+            acceptor: acceptor.clone(),
+        })
     }
 
-    async fn accept_unix(listener: &TokioUnixListener) -> Result<IoStream> {
+    async fn accept_unix(listener: &TokioUnixListener) -> Result<AcceptedStream> {
         let unix_stream = listener.accept().await?;
-        Self::to_tokio_io(Stream::UnixStream(unix_stream), None).await
+        Ok(AcceptedStream::Ready(Self::to_plain_io(
+            Stream::UnixStream(unix_stream),
+        )))
     }
 
     async fn accept_unix_tls(
         listener: &TokioUnixListener,
         acceptor: &ItsiTlsAcceptor,
-    ) -> Result<IoStream> {
-        let unix_stream = listener.accept().await?;
-        match acceptor {
-            ItsiTlsAcceptor::Manual(tls_acceptor) => {
-                Self::to_tokio_io(Stream::UnixStream(unix_stream), Some(tls_acceptor)).await
-            }
-            ItsiTlsAcceptor::Automatic(_, _, _) => {
-                error!("Automatic TLS not supported on Unix sockets");
-                Err(ItsiError::UnsupportedProtocol(
-                    "Automatic TLS on Unix Sockets".to_owned(),
-                ))
-            }
-        }
+    ) -> Result<AcceptedStream> {
+        let (stream, addr) = listener.accept().await?;
+        Ok(AcceptedStream::UnixTls {
+            stream,
+            addr,
+            acceptor: acceptor.clone(),
+        })
     }
 
-    async fn to_tokio_io(
-        input_stream: Stream,
-        tls_acceptor: Option<&TlsAcceptor>,
-    ) -> Result<IoStream> {
-        match tls_acceptor {
-            Some(acceptor) => match input_stream {
-                Stream::TcpStream((tcp_stream, socket_address)) => {
-                    match acceptor.accept(tcp_stream).await {
-                        Ok(tls_stream) => Ok(IoStream::TcpTls {
+    fn to_plain_io(input_stream: Stream) -> IoStream {
+        match input_stream {
+            Stream::TcpStream((tcp_stream, socket_address)) => IoStream::Tcp {
+                stream: tcp_stream,
+                addr: SockAddr::Tcp(Arc::new(socket_address)),
+            },
+            Stream::UnixStream((unix_stream, socket_address)) => IoStream::Unix {
+                stream: unix_stream,
+                addr: SockAddr::Unix(Arc::new(socket_address)),
+            },
+        }
+    }
+}
+
+pub(crate) enum AcceptedStream {
+    Ready(IoStream),
+    TcpTls {
+        stream: TcpStream,
+        addr: SocketAddr,
+        acceptor: ItsiTlsAcceptor,
+    },
+    UnixTls {
+        stream: UnixStream,
+        addr: unix::SocketAddr,
+        acceptor: ItsiTlsAcceptor,
+    },
+}
+
+impl AcceptedStream {
+    pub(crate) async fn into_io_stream(self, handshake_timeout: Duration) -> Result<IoStream> {
+        match self {
+            AcceptedStream::Ready(stream) => Ok(stream),
+            AcceptedStream::TcpTls {
+                stream,
+                addr,
+                acceptor,
+            } => match acceptor {
+                ItsiTlsAcceptor::Manual(tls_acceptor) => {
+                    match timeout(handshake_timeout, tls_acceptor.accept(stream)).await {
+                        Ok(Ok(tls_stream)) => Ok(IoStream::TcpTls {
                             stream: tls_stream,
-                            addr: SockAddr::Tcp(Arc::new(socket_address)),
+                            addr: SockAddr::Tcp(Arc::new(addr)),
                         }),
-                        Err(err) => Err(err.into()),
+                        Ok(Err(error)) => Err(error.into()),
+                        Err(_) => Err(ItsiError::Pass),
                     }
                 }
-                Stream::UnixStream((unix_stream, socket_address)) => {
-                    match acceptor.accept(unix_stream).await {
-                        Ok(tls_stream) => Ok(IoStream::UnixTls {
-                            stream: tls_stream,
-                            addr: SockAddr::Unix(Arc::new(socket_address)),
-                        }),
-                        Err(err) => Err(err.into()),
+                ItsiTlsAcceptor::Automatic(acme_acceptor, _, rustls_config) => {
+                    let accept_future = acme_acceptor.accept(stream);
+                    match timeout(handshake_timeout, accept_future).await {
+                        Err(_) => Err(ItsiError::Pass),
+                        Ok(accept_result) => match accept_result {
+                            Ok(None) => Err(ItsiError::Pass),
+                            Ok(Some(start_handshake)) => {
+                                match timeout(
+                                    handshake_timeout,
+                                    start_handshake.into_stream(rustls_config.clone()),
+                                )
+                                .await
+                                {
+                                    Ok(Ok(tls_stream)) => Ok(IoStream::TcpTls {
+                                        stream: tls_stream,
+                                        addr: SockAddr::Tcp(Arc::new(addr)),
+                                    }),
+                                    Ok(Err(error)) => Err(error.into()),
+                                    Err(_) => Err(ItsiError::Pass),
+                                }
+                            }
+                            Err(error) => {
+                                error!(error = format!("{:?}", error));
+                                Err(ItsiError::Pass)
+                            }
+                        },
                     }
                 }
             },
-            None => match input_stream {
-                Stream::TcpStream((tcp_stream, socket_address)) => Ok(IoStream::Tcp {
-                    stream: tcp_stream,
-                    addr: SockAddr::Tcp(Arc::new(socket_address)),
-                }),
-                Stream::UnixStream((unix_stream, socket_address)) => Ok(IoStream::Unix {
-                    stream: unix_stream,
-                    addr: SockAddr::Unix(Arc::new(socket_address)),
-                }),
+            AcceptedStream::UnixTls {
+                stream,
+                addr,
+                acceptor,
+            } => match acceptor {
+                ItsiTlsAcceptor::Manual(tls_acceptor) => {
+                    match timeout(handshake_timeout, tls_acceptor.accept(stream)).await {
+                        Ok(Ok(tls_stream)) => Ok(IoStream::UnixTls {
+                            stream: tls_stream,
+                            addr: SockAddr::Unix(Arc::new(addr)),
+                        }),
+                        Ok(Err(error)) => Err(error.into()),
+                        Err(_) => Err(ItsiError::Pass),
+                    }
+                }
+                ItsiTlsAcceptor::Automatic(_, _, _) => {
+                    error!("Automatic TLS not supported on Unix sockets");
+                    Err(ItsiError::UnsupportedProtocol(
+                        "Automatic TLS on Unix Sockets".to_owned(),
+                    ))
+                }
             },
         }
     }

--- a/crates/itsi_server/src/server/serve_strategy/acceptor.rs
+++ b/crates/itsi_server/src/server/serve_strategy/acceptor.rs
@@ -1,11 +1,15 @@
 use hyper_util::rt::TokioIo;
-use std::{ops::Deref, pin::Pin, sync::Arc, time::Duration};
+use std::{future::Future, ops::Deref, pin::Pin, sync::Arc, time::Duration};
 use tokio::task::JoinSet;
 use tracing::debug;
 
 use crate::{
     ruby_types::itsi_server::itsi_server_config::ServerParams,
-    server::{binds::listener::ListenerInfo, io_stream::IoStream, request_job::RequestJob},
+    server::{
+        binds::listener::{AcceptedStream, ListenerInfo},
+        io_stream::IoStream,
+        request_job::RequestJob,
+    },
     services::itsi_http_service::{ItsiHttpService, ItsiHttpServiceInner},
 };
 
@@ -34,19 +38,39 @@ pub struct AcceptorArgs {
 }
 
 impl Acceptor {
-    pub(crate) async fn serve_connection(&mut self, stream: IoStream) {
-        let addr = stream.addr();
-        let io: TokioIo<Pin<Box<IoStream>>> = TokioIo::new(Box::pin(stream));
+    pub(crate) async fn serve_accepted_connection(
+        &mut self,
+        stream: AcceptedStream,
+        tls_handshake_timeout: Duration,
+    ) {
+        self.spawn_connection(async move { stream.into_io_stream(tls_handshake_timeout).await });
+    }
+
+    fn spawn_connection<F>(&mut self, stream_future: F)
+    where
+        F: Future<Output = itsi_error::Result<IoStream>> + Send + 'static,
+    {
         let mut shutdown_channel = self.shutdown_receiver.clone();
         let acceptor_args = self.acceptor_args.clone();
-        let service = ItsiHttpService {
-            inner: Arc::new(ItsiHttpServiceInner {
-                acceptor_args: acceptor_args.clone(),
-                addr,
-            }),
-        };
 
         self.join_set.spawn(async move {
+            let stream = match stream_future.await {
+                Ok(stream) => stream,
+                Err(error) => {
+                    debug!("Connection setup failed: {:?}", error);
+                    return;
+                }
+            };
+
+            let addr = stream.addr();
+            let io: TokioIo<Pin<Box<IoStream>>> = TokioIo::new(Box::pin(stream));
+            let service = ItsiHttpService {
+                inner: Arc::new(ItsiHttpServiceInner {
+                    acceptor_args: acceptor_args.clone(),
+                    addr,
+                }),
+            };
+
             let executor = &acceptor_args.strategy.executor;
             let svc = hyper::service::service_fn(move |req| {
                 let service = service.clone();

--- a/crates/itsi_server/src/server/serve_strategy/single_mode.rs
+++ b/crates/itsi_server/src/server/serve_strategy/single_mode.rs
@@ -314,6 +314,7 @@ impl SingleMode {
 
                 let shutdown_rx_for_acme_task = shutdown_receiver.clone();
                 let acme_task_listener_clone = listener.clone();
+                let tls_handshake_timeout = server_params.header_read_timeout;
 
                 let mut after_accept_wait: Option<Duration> = None::<Duration>;
 
@@ -337,7 +338,7 @@ impl SingleMode {
                         tokio::select! {
                             accept_result = listener.accept() => {
                                 match accept_result {
-                                    Ok(accepted) => acceptor.serve_connection(accepted).await,
+                                    Ok(accepted) => acceptor.serve_accepted_connection(accepted, tls_handshake_timeout).await,
                                     Err(e) => debug!("Listener.accept failed: {:?}", e)
                                 }
                                 if cfg!(target_os = "macos") {

--- a/gems/server/Cargo.lock
+++ b/gems/server/Cargo.lock
@@ -1643,6 +1643,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "itsi-scheduler"
+version = "0.2.23"
+dependencies = [
+ "bytes",
+ "derive_more",
+ "itsi_error",
+ "itsi_instrument_entry",
+ "itsi_rb_helpers",
+ "itsi_tracing",
+ "magnus",
+ "mio",
+ "nix",
+ "parking_lot",
+ "rb-sys",
+ "tracing",
+]
+
+[[package]]
 name = "itsi-server"
 version = "0.2.23"
 dependencies = [
@@ -1752,6 +1770,15 @@ dependencies = [
  "nix",
  "rcgen",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "itsi_instrument_entry"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/gems/server/test/helpers/test_helper.rb
+++ b/gems/server/test/helpers/test_helper.rb
@@ -8,6 +8,7 @@ require "itsi/server"
 require "itsi/scheduler"
 require "socket"
 require "net/http"
+require "openssl"
 require "minitest/autorun"
 
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
@@ -157,6 +158,7 @@ class RequestContext
         @uri.host,
         @uri.port,
         use_ssl: @uri.scheme == "https",
+        verify_mode: OpenSSL::SSL::VERIFY_NONE,
         **opts
       )
     end

--- a/gems/server/test/options/tls_handshake_timeout.rb
+++ b/gems/server/test/options/tls_handshake_timeout.rb
@@ -1,0 +1,19 @@
+require_relative "../helpers/test_helper"
+
+class TestTlsHandshakeTimeout < Minitest::Test
+  def test_incomplete_tls_handshake_does_not_block_listener_indefinitely
+    server(
+      protocol: "https",
+      itsi_rb: lambda do
+        header_read_timeout 5.0
+        get("/ok") { |r| r.ok "ok" }
+      end
+    ) do
+      socket = TCPSocket.new("127.0.0.1", @uri.port)
+
+      assert_equal "ok", get("/ok")
+    ensure
+      socket&.close
+    end
+  end
+end


### PR DESCRIPTION
## Summary\n- accept raw sockets before performing TLS handshakes\n- run TLS setup inside per-connection tasks so slow clients cannot block the listener\n- add regression coverage for a stalled TLS ClientHello\n\n## Local verification\n- bundle exec rake server:compile:dev\n- bundle exec ruby -I gems/server/test gems/server/test/options/tls_handshake_timeout.rb\n- bundle exec ruby -I gems/server/test gems/server/test/options/unmatched_request.rb\n- bundle exec ruby -I gems/server/test gems/server/test/options/header_read_timeout.rb\n- bundle exec rake server:test (fails only Redis-backed rate limiter locally because Redis is not running)\n- bundle exec rake test (fails locally because Postgres/Redis are not running)\n